### PR TITLE
Implement `get_coprocessor_version`

### DIFF
--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -274,7 +274,7 @@ class OTBR:  # pylint: disable=too-few-public-methods
 
     async def get_coprocessor_version(self) -> str:
         """Get the coprocessor firmware version.
-        
+
         Raises if the http status is not 200 or if the response is invalid.
         """
 

--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -271,3 +271,23 @@ class OTBR:  # pylint: disable=too-few-public-methods
             return bytes.fromhex(await response.json())
         except ValueError as exc:
             raise OTBRError("unexpected API response") from exc
+
+    async def get_coprocessor_version(self) -> str:
+        """Get the coprocessor firmware version.
+        
+        Raises if the http status is not 200 or if the response is invalid.
+        """
+
+        response = await self._session.get(
+            f"{self._url}/node/coprocessor/version",
+            headers={"Accept": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=self._timeout),
+        )
+
+        if response.status != HTTPStatus.OK:
+            raise OTBRError(f"unexpected http status {response.status}")
+
+        try:
+            return await response.json()
+        except ValueError as exc:
+            raise OTBRError("unexpected API response") from exc

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -446,6 +446,20 @@ async def test_get_extended_address(aioclient_mock: AiohttpClientMocker) -> None
     assert await otbr.get_extended_address() == bytes.fromhex(mock_response)
 
 
+async def test_get_coprocessor_version(aioclient_mock: AiohttpClientMocker) -> None:
+    """Test get_coprocessor_version."""
+    otbr = python_otbr_api.OTBR(BASE_URL, aioclient_mock.create_session())
+
+    mock_response = (
+        "OPENTHREAD/thread-reference-20200818-1740-g33cc75ed3;"
+        " NRF52840; Jun 2 2022 14:25:49"
+    )
+
+    aioclient_mock.get(f"{BASE_URL}/node/coprocessor/version", json=mock_response)
+
+    assert await otbr.get_coprocessor_version() == mock_response
+
+
 async def test_set_enabled_201(aioclient_mock: AiohttpClientMocker) -> None:
     """Test set_enabled."""
     otbr = python_otbr_api.OTBR(BASE_URL, aioclient_mock.create_session())
@@ -639,3 +653,15 @@ async def test_get_extended_address_invalid(aioclient_mock: AiohttpClientMocker)
     aioclient_mock.get(f"{BASE_URL}/node/ext-address", text="unexpected")
     with pytest.raises(python_otbr_api.OTBRError):
         await otbr.get_extended_address()
+
+
+async def test_get_coprocessor_version_invalid(aioclient_mock: AiohttpClientMocker):
+    """Test get_coprocessor_version with error."""
+    otbr = python_otbr_api.OTBR(BASE_URL, aioclient_mock.create_session())
+
+    aioclient_mock.get(
+        f"{BASE_URL}/node/coprocessor/version", status=HTTPStatus.NOT_FOUND
+    )
+
+    with pytest.raises(python_otbr_api.OTBRError):
+        await otbr.get_coprocessor_version()


### PR DESCRIPTION
This was added to OTBR a bit ago in https://github.com/openthread/ot-br-posix/pull/2602.

I've tested this change via https://github.com/home-assistant/addons/pull/3890.