### PR TITLE
Bump version to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name         = "python-otbr-api"
-version      = "2.6.0"
+version      = "2.7.0"
 license      = {text = "MIT"}
 description  = "API to interact with an OTBR via its REST API"
 readme       = "README.md"


### PR DESCRIPTION
The 2.7.0 release failed due to the version not being bumped: https://github.com/home-assistant-libs/python-otbr-api/actions/runs/12772200218/job/35601181676