### PR TITLE
Add support for /.well-known/thread/br-rest API discovery

### DIFF
--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, auto
 from http import HTTPStatus
 from typing import Any
 import json
@@ -72,6 +72,15 @@ class KeyFormat(Enum):
     PASCAL_CASE = "pascal"
 
 
+class _UndefinedType(Enum):
+    """Singleton sentinel distinguishing "not probed yet" from a probed None."""
+
+    UNDEFINED = auto()
+
+
+_UNDEFINED = _UndefinedType.UNDEFINED
+
+
 class OTBRError(Exception):
     """Raised on error."""
 
@@ -111,8 +120,7 @@ class OTBR:  # pylint: disable=too-few-public-methods
         self._url = url
         self._timeout = timeout
         self._key_format = key_format
-        self._api_version: str | None = None
-        self._api_version_checked = False
+        self._api_version: str | None | _UndefinedType = _UNDEFINED
 
     async def _maybe_detect_key_format(self) -> None:
         """Probe the OTBR REST API to determine the JSON key format."""
@@ -411,18 +419,14 @@ class OTBR:  # pylint: disable=too-few-public-methods
             raise OTBRError("unexpected API response") from exc
 
     async def get_api_version(self) -> str | None:
-        """Get the OTBR REST API's semantic version, if the router advertises one.
+        """Get the OTBR REST API's semantic version.
 
-        Reads `/.well-known/thread/br-rest` (RFC 8615), added in ot-br-posix
-        PR #3330 (merged 2026-07-07). Returns a semver string such as
-        "0.3.0", or None on routers that predate that PR and don't expose
-        the endpoint (a 404 is not an error: it just means "unknown").
-        The result is cached for the lifetime of this OTBR instance.
-
-        Raises OTBRError if the endpoint exists but responds with an
-        unexpected status or a malformed body.
+        Reads /.well-known/thread/br-rest (ot-br-posix PR #3330). Returns
+        None on routers that don't expose it. Raises OTBRError if the
+        endpoint exists but responds with an unexpected status or a
+        malformed body.
         """
-        if self._api_version_checked:
+        if self._api_version is not _UNDEFINED:
             return self._api_version
 
         response = await self._session.get(
@@ -431,7 +435,7 @@ class OTBR:  # pylint: disable=too-few-public-methods
         )
 
         if response.status == HTTPStatus.NOT_FOUND:
-            self._api_version_checked = True
+            self._api_version = None
             return None
 
         if response.status != HTTPStatus.OK:
@@ -439,10 +443,10 @@ class OTBR:  # pylint: disable=too-few-public-methods
 
         try:
             data = await response.json()
-            self._api_version = data["api"]["version"]
+            api_version: str = data["api"]["version"]
         except (ValueError, KeyError, TypeError) as exc:
             raise OTBRError("unexpected API response") from exc
 
-        self._api_version_checked = True
-        _LOGGER.debug("Detected OTBR REST API version: %s", self._api_version)
-        return self._api_version
+        self._api_version = api_version
+        _LOGGER.debug("Detected OTBR REST API version: %s", api_version)
+        return api_version

--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -111,6 +111,8 @@ class OTBR:  # pylint: disable=too-few-public-methods
         self._url = url
         self._timeout = timeout
         self._key_format = key_format
+        self._api_version: str | None = None
+        self._api_version_checked = False
 
     async def _maybe_detect_key_format(self) -> None:
         """Probe the OTBR REST API to determine the JSON key format."""
@@ -407,3 +409,40 @@ class OTBR:  # pylint: disable=too-few-public-methods
             return await response.json()
         except ValueError as exc:
             raise OTBRError("unexpected API response") from exc
+
+    async def get_api_version(self) -> str | None:
+        """Get the OTBR REST API's semantic version, if the router advertises one.
+
+        Reads `/.well-known/thread/br-rest` (RFC 8615), added in ot-br-posix
+        PR #3330 (merged 2026-07-07). Returns a semver string such as
+        "0.3.0", or None on routers that predate that PR and don't expose
+        the endpoint (a 404 is not an error: it just means "unknown").
+        The result is cached for the lifetime of this OTBR instance.
+
+        Raises OTBRError if the endpoint exists but responds with an
+        unexpected status or a malformed body.
+        """
+        if self._api_version_checked:
+            return self._api_version
+
+        response = await self._session.get(
+            f"{self._url}/.well-known/thread/br-rest",
+            timeout=aiohttp.ClientTimeout(total=self._timeout),
+        )
+
+        if response.status == HTTPStatus.NOT_FOUND:
+            self._api_version_checked = True
+            return None
+
+        if response.status != HTTPStatus.OK:
+            raise OTBRError(f"unexpected http status {response.status}")
+
+        try:
+            data = await response.json()
+            self._api_version = data["api"]["version"]
+        except (ValueError, KeyError, TypeError) as exc:
+            raise OTBRError("unexpected API response") from exc
+
+        self._api_version_checked = True
+        _LOGGER.debug("Detected OTBR REST API version: %s", self._api_version)
+        return self._api_version

--- a/tests/test_well_known.py
+++ b/tests/test_well_known.py
@@ -1,0 +1,108 @@
+"""Tests for the /.well-known/thread/br-rest API discovery endpoint."""
+
+from http import HTTPStatus
+
+import pytest
+import python_otbr_api
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+BASE_URL = "http://core-openthread-border-router:8081"
+
+WELL_KNOWN_JSON = {
+    "api": {"version": "0.3.0", "base": "/api/"},
+    "links": [
+        {
+            "href": "/.well-known/thread/br-rest",
+            "rel": "self",
+            "type": ["application/json"],
+        },
+        {"href": "/api/node", "rel": "node", "type": ["application/vnd.api+json"]},
+        {"href": "/api/actions", "rel": "task", "type": ["application/vnd.api+json"]},
+        {
+            "href": "/api/devices",
+            "rel": "device",
+            "type": ["application/vnd.api+json"],
+        },
+        {
+            "href": "/api/diagnostics",
+            "rel": "diagnostic",
+            "type": ["application/vnd.api+json"],
+        },
+    ],
+}
+
+
+def _otbr(aioclient_mock: AiohttpClientMocker) -> python_otbr_api.OTBR:
+    return python_otbr_api.OTBR(BASE_URL, aioclient_mock.create_session())
+
+
+async def test_get_api_version(aioclient_mock: AiohttpClientMocker) -> None:
+    """A 200 with a version resource returns the advertised semver string."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(f"{BASE_URL}/.well-known/thread/br-rest", json=WELL_KNOWN_JSON)
+
+    assert await otbr.get_api_version() == "0.3.0"
+
+
+async def test_get_api_version_not_supported(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """A 404 means the router predates ot-br-posix #3330: version is unknown."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(
+        f"{BASE_URL}/.well-known/thread/br-rest", status=HTTPStatus.NOT_FOUND
+    )
+
+    assert await otbr.get_api_version() is None
+
+
+async def test_get_api_version_unexpected_status(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Any other non-200 status raises OTBRError."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(
+        f"{BASE_URL}/.well-known/thread/br-rest",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+
+    with pytest.raises(python_otbr_api.OTBRError):
+        await otbr.get_api_version()
+
+
+async def test_get_api_version_malformed_body(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """A 200 without the expected `api.version` field raises OTBRError."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(f"{BASE_URL}/.well-known/thread/br-rest", json={"api": {}})
+
+    with pytest.raises(python_otbr_api.OTBRError):
+        await otbr.get_api_version()
+
+
+async def test_get_api_version_runs_once(aioclient_mock: AiohttpClientMocker) -> None:
+    """Detection happens lazily on first call and is cached for subsequent calls."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(f"{BASE_URL}/.well-known/thread/br-rest", json=WELL_KNOWN_JSON)
+
+    assert await otbr.get_api_version() == "0.3.0"
+    assert await otbr.get_api_version() == "0.3.0"
+
+    assert aioclient_mock.call_count == 1
+
+
+async def test_get_api_version_not_supported_runs_once(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """A 404 result is cached too, so repeated calls don't re-probe."""
+    otbr = _otbr(aioclient_mock)
+    aioclient_mock.get(
+        f"{BASE_URL}/.well-known/thread/br-rest", status=HTTPStatus.NOT_FOUND
+    )
+
+    assert await otbr.get_api_version() is None
+    assert await otbr.get_api_version() is None
+
+    assert aioclient_mock.call_count == 1


### PR DESCRIPTION
## Summary
- Adds `OTBR.get_api_version()`, which reads the RFC 8615 discovery resource `GET /.well-known/thread/br-rest` added in [ot-br-posix PR #3330](https://github.com/openthread/ot-br-posix/pull/3330) (merged 2026-07-07)
- Returns the router's advertised REST API semver string (e.g. `"0.3.0"`), or `None` on routers that predate that PR and don't expose the endpoint (a 404 is treated as "unknown", not an error)
- Result is cached for the lifetime of the `OTBR` instance

Kept independent of `_maybe_detect_key_format`/`KeyFormat`: the discovery endpoint's JSON shape is unrelated to the PascalCase/camelCase dataset wire format, and this avoids touching the already well-tested detection flow.

## Why
This is a first step towards feature-gating on the REST API version instead of relying only on reactive 404 handling. In particular it's meant as a foundation for #267 (ephemeral key / ePSKc client support): once ePSKc actually lands upstream in ot-br-posix with a version bump, we'll be able to use `get_api_version()` to detect support declaratively instead of only via try/except on the ePSKc endpoints. For now #267's reactive 404 detection is unaffected and remains the mechanism used for ePSKc, since the discovery resource's `links` don't currently list `ba-epskc`.

## Test plan
- [x] `pytest` — full suite passes (81 tests, 7 new)
- [x] `mypy` — clean
- [x] `pylint` — 10/10
- [x] `black`/`flake8` — clean
