### PR TITLE
Support conditional pending-dataset replaces with entity tags

### DIFF
--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -114,7 +114,11 @@ class EphemeralKeyConflictError(OTBRError):
 
 
 class PendingDatasetConflictError(OTBRError):
-    """Raised when a pending dataset write is refused because one is in place.
+    """Raised when a pending dataset write is refused.
+
+    Either a pending dataset is already in place for a guarded write, or the
+    one whose entity tag the write carried has been replaced since it was
+    read.
 
     Its own type rather than a plain OTBRError: the caller's next step is
     different from the one a transport or protocol failure calls for, since
@@ -281,6 +285,21 @@ class OTBR:  # pylint: disable=too-many-public-methods
         Returns None if there is no pending operational dataset.
         Raises if the http status is 400 or higher or if the response is invalid.
         """
+        result = await self.get_pending_dataset_tlvs_with_etag()
+        return None if result is None else result[0]
+
+    async def get_pending_dataset_tlvs_with_etag(
+        self,
+    ) -> tuple[bytes, str | None] | None:
+        """Get the pending dataset TLVs together with its entity tag, or None.
+
+        Returns None if there is no pending operational dataset. The entity
+        tag is None on a border router that does not hand one out; when it
+        does (https://github.com/openthread/ot-br-posix/pull/3553), the tag
+        can be passed to set_pending_dataset_tlvs() as if_match to only
+        replace the dataset that was read here.
+        Raises if the http status is 400 or higher or if the response is invalid.
+        """
         await self._maybe_detect_key_format()
         response = await self._session.get(
             f"{self._url}/node/dataset/pending",
@@ -295,7 +314,10 @@ class OTBR:  # pylint: disable=too-many-public-methods
             raise OTBRError(f"unexpected http status {response.status}")
 
         try:
-            return bytes.fromhex(await response.text("ASCII"))
+            return (
+                bytes.fromhex(await response.text("ASCII")),
+                response.headers.get("ETag"),
+            )
         except ValueError as exc:
             raise OTBRError("unexpected API response") from exc
 
@@ -381,7 +403,9 @@ class OTBR:  # pylint: disable=too-many-public-methods
         if response.status not in (HTTPStatus.CREATED, HTTPStatus.OK):
             raise OTBRError(f"unexpected http status {response.status}")
 
-    async def set_pending_dataset_tlvs(self, dataset: bytes) -> None:
+    async def set_pending_dataset_tlvs(
+        self, dataset: bytes, *, if_match: str | None = None
+    ) -> None:
         """Set the pending operational dataset, when none is in place yet.
 
         A write while a pending dataset is in flight is refused outright.
@@ -397,23 +421,45 @@ class OTBR:  # pylint: disable=too-many-public-methods
         (https://github.com/openthread/ot-br-posix/pull/3552), where it is
         atomic with the write; older border routers ignore the header.
 
-        Raises PendingDatasetConflictError when either check refuses the
-        write, and OTBRError if the http status is 400 or higher for any
+        The one deliberate way to replace an in-flight dataset is by its
+        entity tag: a caller that read it via
+        get_pending_dataset_tlvs_with_etag() passes the tag as if_match, and
+        the write then only replaces exactly the dataset that was read,
+        refused if it changed in between. That check happens on the border
+        router, atomically with the write, so no local check runs on this
+        path; an older border router that hands out no entity tags ignores
+        the header, making the replace there unconditional, which is why a
+        caller must only offer this as an explicit, informed choice.
+
+        Raises PendingDatasetConflictError when any of these checks refuses
+        the write, and OTBRError if the http status is 400 or higher for any
         other reason or the response is invalid.
         """
-        if await self.get_pending_dataset_tlvs() is not None:
-            raise PendingDatasetConflictError("a pending dataset is already in place")
+        if if_match is None:
+            if await self.get_pending_dataset_tlvs() is not None:
+                raise PendingDatasetConflictError(
+                    "a pending dataset is already in place"
+                )
         await self._maybe_detect_key_format()
+        headers = {"Content-Type": "text/plain"}
+        if if_match is not None:
+            headers["If-Match"] = if_match
+        else:
+            headers["If-None-Match"] = "*"
         response = await self._session.put(
             f"{self._url}/node/dataset/pending",
             data=dataset.hex(),
-            headers={"Content-Type": "text/plain", "If-None-Match": "*"},
+            headers=headers,
             timeout=aiohttp.ClientTimeout(total=10),
         )
 
         if response.status == HTTPStatus.CONFLICT:
             raise ThreadNetworkActiveError
         if response.status == HTTPStatus.PRECONDITION_FAILED:
+            if if_match is not None:
+                raise PendingDatasetConflictError(
+                    "the pending dataset changed since it was read"
+                )
             raise PendingDatasetConflictError("a pending dataset is already in place")
         if response.status not in (HTTPStatus.CREATED, HTTPStatus.OK):
             raise OTBRError(f"unexpected http status {response.status}")

--- a/tests/test_init_legacy.py
+++ b/tests/test_init_legacy.py
@@ -864,6 +864,90 @@ async def test_set_pending_dataset_tlvs_refused_by_router(
         await otbr.set_pending_dataset_tlvs(b"")
 
 
+async def test_get_pending_dataset_tlvs_with_etag(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test get_pending_dataset_tlvs_with_etag."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    mock_response = "0E080000000000010000340400006699000300000C"
+    aioclient_mock.get(
+        f"{BASE_URL}/node/dataset/pending",
+        text=mock_response,
+        headers={"ETag": '"8311BDCD94E7107C"'},
+    )
+
+    assert await otbr.get_pending_dataset_tlvs_with_etag() == (
+        bytes.fromhex(mock_response),
+        '"8311BDCD94E7107C"',
+    )
+
+
+async def test_get_pending_dataset_tlvs_with_etag_no_tag(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the tag is None on a border router that hands out none."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    mock_response = "0E080000000000010000340400006699000300000C"
+    aioclient_mock.get(f"{BASE_URL}/node/dataset/pending", text=mock_response)
+
+    assert await otbr.get_pending_dataset_tlvs_with_etag() == (
+        bytes.fromhex(mock_response),
+        None,
+    )
+
+
+async def test_get_pending_dataset_tlvs_with_etag_empty(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test get_pending_dataset_tlvs_with_etag without a pending dataset."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    aioclient_mock.get(f"{BASE_URL}/node/dataset/pending", status=HTTPStatus.NO_CONTENT)
+    assert await otbr.get_pending_dataset_tlvs_with_etag() is None
+
+
+async def test_set_pending_dataset_tlvs_if_match(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test if_match makes the replace conditional on the tag, with no local check."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    dataset = bytes.fromhex("0E080000000000010000340400006699000300000C")
+    aioclient_mock.put(f"{BASE_URL}/node/dataset/pending", status=HTTPStatus.OK)
+
+    await otbr.set_pending_dataset_tlvs(dataset, if_match='"8311BDCD94E7107C"')
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[-1][0] == "PUT"
+    assert aioclient_mock.mock_calls[-1][3]["If-Match"] == '"8311BDCD94E7107C"'
+    assert "If-None-Match" not in aioclient_mock.mock_calls[-1][3]
+
+
+async def test_set_pending_dataset_tlvs_if_match_changed(
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test a conditional replace of a dataset that changed is surfaced."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    aioclient_mock.put(
+        f"{BASE_URL}/node/dataset/pending", status=HTTPStatus.PRECONDITION_FAILED
+    )
+
+    with pytest.raises(python_otbr_api.PendingDatasetConflictError):
+        await otbr.set_pending_dataset_tlvs(b"", if_match='"8311BDCD94E7107C"')
+
+
 async def test_set_pending_dataset_tlvs_202(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:


### PR DESCRIPTION
**Draft until openthread/ot-br-posix#3553 is merged** -- that is the border-router side of the API this exposes. (#269, which this builds on, has merged.)

`set_pending_dataset_tlvs()` refuses outright while a pending dataset is in flight (#269), because replacing one implicitly is never safe. But a caller that read the in-flight dataset, showed it to the user, and stamped a successor above it has a legitimate replace -- and still cannot say "replace exactly the one I read": another controller can slip a new pending dataset in between the read and the write.

This adds `get_pending_dataset_tlvs_with_etag()`, returning the dataset together with the entity tag a border router hands out for it, and an `if_match` keyword on `set_pending_dataset_tlvs()` that passes the tag back: the router then only replaces the dataset the tag stands for, checked atomically with the write (openthread/ot-br-posix#3553), and a 412 raises `PendingDatasetConflictError` telling the caller the dataset changed since it was read. This is the only way the library replaces a pending dataset. An older border router hands out no tag (the getter returns `None` for it) and would ignore the `If-Match` header, silently making the write unconditional -- which is why a caller must only offer `if_match` as an explicit, informed choice, and refuse it when the getter returned no tag.

Needed for the replace-pending follow-up to home-assistant/core#178291 (the `otbr.migrate_network` action gains an explicit `replace_pending` option that passes the tag back, so a migration only supersedes the in-flight dataset the user actually saw).

**AI use:** Written with AI assistance -- the commit carries an `Assisted-By` trailer. I've reviewed and understand all of it, and will be answering questions myself.

