### PR TITLE
Bump version from 2.11.0 to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name         = "python-otbr-api"
-version      = "2.11.0"
+version      = "3.0.0"
 license      = {text = "MIT"}
 description  = "API to interact with an OTBR via its REST API"
 readme       = "README.md"


### PR DESCRIPTION
Major rather than minor: 2.11.0 was never released (the latest tag is 2.10.0), so one release can cover both breaking changes honestly instead of shipping them as minors.

- #269 tightened `parse_tlv()`: a malformed `PENDINGTIMESTAMP` or `DELAYTIMER` now raises `TLVError` instead of parsing into an untyped item, and those two tags decode to `Timestamp` / `DelayTimer` rather than `MeshcopTLVItem`. Input that previously parsed can now be rejected.
- #275 makes `create_pending_dataset()` refuse while a pending dataset is in place, where it previously replaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)