### PR TITLE
Add a getter for the router's Thread device role

### DIFF
--- a/python_otbr_api/__init__.py
+++ b/python_otbr_api/__init__.py
@@ -13,6 +13,7 @@ import voluptuous as vol  # type: ignore[import]
 
 from .models import (
     ActiveDataSet,
+    DeviceRole,
     EphemeralKeyActivationResult,
     EphemeralKeyState,
     EphemeralKeyStatus,
@@ -227,6 +228,29 @@ class OTBR:  # pylint: disable=too-many-public-methods
 
         if response.status != HTTPStatus.OK:
             raise OTBRError(f"unexpected http status {response.status}")
+
+    async def get_device_role(self) -> DeviceRole:
+        """Get the role the router has in its Thread network.
+
+        Reads /node/state, which reports the OpenThread device role.
+
+        Raises if the http status is not 200, or if the role is not one this
+        library knows.
+        """
+        await self._maybe_detect_key_format()
+        response = await self._session.get(
+            f"{self._url}/node/state",
+            headers={"Accept": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=self._timeout),
+        )
+
+        if response.status != HTTPStatus.OK:
+            raise OTBRError(f"unexpected http status {response.status}")
+
+        try:
+            return DeviceRole(await response.json())
+        except ValueError as exc:
+            raise OTBRError("unexpected API response") from exc
 
     async def get_active_dataset(self) -> ActiveDataSet | None:
         """Get current active operational dataset.

--- a/python_otbr_api/models.py
+++ b/python_otbr_api/models.py
@@ -9,6 +9,30 @@ from typing import Any
 import voluptuous as vol  # type: ignore[import]
 
 
+class DeviceRole(Enum):
+    """Role the border router has in its Thread network.
+
+    Reported by the `/node/state` endpoint. See otDeviceRole in
+    openthread/thread.h.
+    """
+
+    DISABLED = "disabled"
+    DETACHED = "detached"
+    CHILD = "child"
+    ROUTER = "router"
+    LEADER = "leader"
+
+    @property
+    def is_attached(self) -> bool:
+        """Return whether the router is attached to a Thread network.
+
+        A router that is not attached reaches no other device: a pending
+        dataset written to it is applied to its own active dataset when the
+        delay timer expires and never reaches the mesh.
+        """
+        return self in (DeviceRole.CHILD, DeviceRole.ROUTER, DeviceRole.LEADER)
+
+
 class EphemeralKeyState(Enum):
     """State of the border agent ephemeral key (ePSKc) session.
 

--- a/tests/test_init_legacy.py
+++ b/tests/test_init_legacy.py
@@ -549,6 +549,55 @@ async def test_get_coprocessor_version(aioclient_mock: AiohttpClientMocker) -> N
     assert await otbr.get_coprocessor_version() == mock_response
 
 
+@pytest.mark.parametrize(
+    ("role", "attached"),
+    [
+        ("disabled", False),
+        ("detached", False),
+        ("child", True),
+        ("router", True),
+        ("leader", True),
+    ],
+)
+async def test_get_device_role(
+    aioclient_mock: AiohttpClientMocker, role: str, attached: bool
+) -> None:
+    """Test get_device_role."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    aioclient_mock.get(f"{BASE_URL}/node/state", json=role)
+
+    reported = await otbr.get_device_role()
+    assert reported is python_otbr_api.DeviceRole(role)
+    assert reported.is_attached is attached
+
+
+async def test_get_device_role_201(aioclient_mock: AiohttpClientMocker) -> None:
+    """Test get_device_role with an unexpected status."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    aioclient_mock.get(f"{BASE_URL}/node/state", status=HTTPStatus.CREATED)
+
+    with pytest.raises(python_otbr_api.OTBRError):
+        await otbr.get_device_role()
+
+
+async def test_get_device_role_unknown(aioclient_mock: AiohttpClientMocker) -> None:
+    """Test get_device_role with a role this library does not know."""
+    otbr = python_otbr_api.OTBR(
+        BASE_URL, aioclient_mock.create_session(), key_format=KeyFormat.PASCAL_CASE
+    )
+
+    aioclient_mock.get(f"{BASE_URL}/node/state", json="commissioner")
+
+    with pytest.raises(python_otbr_api.OTBRError):
+        await otbr.get_device_role()
+
+
 async def test_set_enabled_201(aioclient_mock: AiohttpClientMocker) -> None:
     """Test set_enabled."""
     otbr = python_otbr_api.OTBR(


### PR DESCRIPTION
Adds `OTBR.get_device_role()`, returning a new `DeviceRole` enum, and a
`DeviceRole.is_attached` property.

**Why.** A pending operational dataset is accepted by the REST API in any device
role: `RestWebServer::SetDataset` gates only the *active* dataset PUT on
`OT_DEVICE_ROLE_DISABLED`, and OpenThread's `PendingDatasetManager::HandleDelayTimer`
has no role check either. So a pending dataset written to a router that is disabled
or detached is accepted, the delay timer runs, and when it expires it rewrites that
router's own active dataset - no other device ever sees it. In the worst case the
border router alone ends up on the new network and leaves the mesh.

There is currently no way for a caller to tell that apart from a write that will
actually reach the mesh. `get_active_dataset()`, `get_border_agent_id()` and
`get_extended_address()` all answer normally in every role.

**What it does.** Reads `GET /node/state`, which returns the OpenThread device role
as a JSON string (`disabled`, `detached`, `child`, `router`, `leader` - see
`GetDeviceRoleName()` in ot-br-posix `src/common/api_strings.cpp`). An unknown role
raises `OTBRError` rather than defaulting silently, matching how an unknown
ephemeral key state is handled.

**Naming.** The endpoint is `/node/state`, but "state" is overloaded in the OTBR API
(border agent state, ephemeral key state, commissioner state), and the value is
unambiguously the device role, so the method and the enum are named for what they
return. The endpoint is named in the docstring.

`is_attached` is included because that is the question every caller has, and getting
it wrong is silent: `DETACHED` is the easy one to forget.

Tests cover all five roles including `is_attached`, an unexpected HTTP status, and an
unknown role.

**Consumer.** home-assistant/core#178291 (the `otbr.migrate_network` action) needs
this to refuse a migration on a router that is not attached, instead of reporting a
successful migration that never reaches the mesh. That PR is gated on a release
containing this.

Written with AI assistance (`Assisted-by` trailer); I've reviewed and understand all
of it and will answer questions myself.